### PR TITLE
Fix path to "true" for lucas_server execution

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ if(BUILD_CODE_COVERAGE)
   set(test_runner "${CMAKE_CURRENT_BINARY_DIR}/run_test.sh")
   file(WRITE ${test_runner}
     "cd \"${CMAKE_CURRENT_BINARY_DIR}/test\"\n"
-    "ctest||/usr/bin/true"
+    "ctest||/bin/true"
     )
   # Create target for code coverage
   SETUP_TARGET_FOR_COVERAGE_LCOV(


### PR DESCRIPTION
The unified /usr/ file system is not used on every Unix platform. Thus
searching for "true" in /bin/true seems a better idea than in
/usr/bin/true.

FIXME: A better idea would be to use CMake's find_program to locate "true".